### PR TITLE
docs: document optional extras (precily, xgboost, multiprocessing)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,6 +46,46 @@ Then, install the package using pip:
    pip install drevalpy
 
 
+Optional Features (Extras)
+--------------------------
+
+Some models and features require additional dependencies that are **not** installed by the
+default ``pip install drevalpy``. They are provided as optional `extras`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Extra
+     - Enables
+     - Extra dependencies
+   * - ``precily``
+     - The ``Precily`` model (GSVA pathway features)
+     - ``gseapy``
+   * - ``xgboost``
+     - The ``MultiViewXGBoost`` baseline model
+     - ``xgboost``
+   * - ``multiprocessing``
+     - Parallelized cross-validation / tuning via Ray
+     - ``ray`` (and ``pydantic``, usually already present)
+
+Install one or more extras by listing them in square brackets, for example:
+
+.. code-block:: bash
+
+   pip install "drevalpy[precily]"
+   pip install "drevalpy[precily,xgboost,multiprocessing]"
+
+If you install from source with Poetry, install the extras with ``-E`` (or use
+``--all-extras`` to install all of them):
+
+.. code-block:: bash
+
+   poetry install -E precily -E xgboost -E multiprocessing
+   # or, equivalently
+   poetry install --all-extras
+
+
 With Docker
 -----------
 


### PR DESCRIPTION
## What & why
The installation docs (`docs/installation.rst`) only show `pip install drevalpy`, which does **not** install the optional dependencies declared as poetry `extras`. As a result, models that rely on an extra fail at runtime with a `ModuleNotFoundError`.

Concrete case I hit: the **Precily** model imports `gseapy` (lazily, in `drevalpy/datasets/featurizer/create_precily_pathway_features.py`), but `gseapy` lives in the optional `precily` extra. A user following the docs (`pip install drevalpy`) gets a clean import but a crash as soon as Precily pathway features are computed — with no hint that an extra is required.

## Change
Adds an **"Optional Features (Extras)"** section to `docs/installation.rst` that:
- lists the available extras and what each enables:
  | Extra | Enables | Extra deps |
  |---|---|---|
  | `precily` | `Precily` model (GSVA pathway features) | `gseapy` |
  | `xgboost` | `MultiViewXGBoost` baseline | `xgboost` |
  | `multiprocessing` | Ray-based parallel CV / tuning | `ray` (pulls pyarrow, tensorboardx, etc. transitively; pydantic is usually already present) |
- shows how to install them: `pip install "drevalpy[precily]"` etc.
- notes that `poetry install` from source also skips extras → use `poetry install -E ...` or `--all-extras`.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)