### PR TITLE
docs: use --dataset_name in colab demo report command

### DIFF
--- a/dreval_colab_demo.ipynb
+++ b/dreval_colab_demo.ipynb
@@ -1007,7 +1007,7 @@
    "source": [
     "# We prefer running this in the console:\n",
     "!drevalpy --models RandomForest --dataset_name TOYv1 --n_cv_splits 2 --test_mode LPO --run_id my_second_run --no_hyperparameter_tuning\n",
-    "!drevalpy report --run_id my_second_run --dataset TOYv1"
+    "!drevalpy report --run_id my_second_run --dataset_name TOYv1"
    ],
    "outputs": [
     {


### PR DESCRIPTION
## Summary
Follow-up to #429. That PR renamed the `drevalpy report` CLI option from `--dataset` to `--dataset_name` (and updated the docs), but the Colab demo notebook (`dreval_colab_demo.ipynb`) still used the old `--dataset` flag.

With the current CLI this fails:
```
!drevalpy report --run_id my_second_run --dataset TOYv1
# Error: No such option: --dataset
```

## Change
- `dreval_colab_demo.ipynb`: `drevalpy report ... --dataset TOYv1` → `--dataset_name TOYv1` (one line).

The Python API call `create_report(run_id=..., dataset="TOYv1")` in the same notebook is intentionally left unchanged — #429 only renamed the CLI option, the `create_report()` parameter is still `dataset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)