### PR TITLE
Add tissue term to mean effects baseline

### DIFF
--- a/drevalpy/models/baselines/naive_pred.py
+++ b/drevalpy/models/baselines/naive_pred.py
@@ -575,9 +575,7 @@ class NaiveMeanEffectsPredictor(NaiveModel):
             if len(responses_tissue) > 0:
                 tissue_means[tissue_key] = np.mean(responses_tissue)
 
-        self.tissue_effects = {
-            tissue: (mean - self.dataset_mean) for tissue, mean in tissue_means.items()
-        }
+        self.tissue_effects = {tissue: (mean - self.dataset_mean) for tissue, mean in tissue_means.items()}
 
         cell_line_ids = cell_line_input.get_feature_matrix(view=CELL_LINE_IDENTIFIER, identifiers=output.cell_line_ids)
         cell_line_means = {}

--- a/drevalpy/models/baselines/naive_pred.py
+++ b/drevalpy/models/baselines/naive_pred.py
@@ -515,9 +515,11 @@ class NaiveMeanEffectsPredictor(NaiveModel):
 
     This formulation avoids double-counting tissue signal already captured by cell line means.
     For unseen cell lines with a known tissue, the tissue effect provides a fallback.
+    If tissue information is not available, this model falls back to the previous formulation:
+    response = overall_mean + cell_line_effect + drug_effect.
     """
 
-    cell_line_views = [CELL_LINE_IDENTIFIER, TISSUE_IDENTIFIER]
+    cell_line_views = [CELL_LINE_IDENTIFIER]
     drug_views = [DRUG_IDENTIFIER]
 
     def __init__(self):
@@ -564,35 +566,41 @@ class NaiveMeanEffectsPredictor(NaiveModel):
 
         self.dataset_mean = np.mean(output.response)
 
-        tissues = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=output.cell_line_ids)
-        tissues = np.asarray(tissues).flatten()
-
-        tissue_means = {}
-        for tissue in np.unique(tissues):
-            tissue_key = str(tissue.item() if isinstance(tissue, np.ndarray) else tissue)
-            mask = tissues == tissue
-            responses_tissue = output.response[mask]
-            if len(responses_tissue) > 0:
-                tissue_means[tissue_key] = np.mean(responses_tissue)
-
-        self.tissue_effects = {tissue: (mean - self.dataset_mean) for tissue, mean in tissue_means.items()}
-
         cell_line_ids = cell_line_input.get_feature_matrix(view=CELL_LINE_IDENTIFIER, identifiers=output.cell_line_ids)
         cell_line_means = {}
-        cell_line_to_tissue = {}
         for cl_output, cl_feature in zip(unique(output.cell_line_ids), unique(cell_line_ids), strict=True):
-            mask = cl_feature == output.cell_line_ids
-            responses_cl = output.response[mask]
+            responses_cl = output.response[cl_feature == output.cell_line_ids]
             if len(responses_cl) > 0:
                 cell_line_means[cl_output] = np.mean(responses_cl)
+
+        if TISSUE_IDENTIFIER in cell_line_input.view_names:
+            tissues = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=output.cell_line_ids)
+            tissues = np.asarray(tissues).flatten()
+
+            tissue_means = {}
+            for tissue in np.unique(tissues):
+                tissue_key = str(tissue.item() if isinstance(tissue, np.ndarray) else tissue)
+                mask = tissues == tissue
+                responses_tissue = output.response[mask]
+                if len(responses_tissue) > 0:
+                    tissue_means[tissue_key] = np.mean(responses_tissue)
+
+            self.tissue_effects = {tissue: (mean - self.dataset_mean) for tissue, mean in tissue_means.items()}
+
+            cell_line_to_tissue = {}
+            for cl_output, cl_feature in zip(unique(output.cell_line_ids), unique(cell_line_ids), strict=True):
+                mask = cl_feature == output.cell_line_ids
                 tissue = tissues[mask][0]
                 tissue_key = tissue.item() if isinstance(tissue, np.ndarray) else tissue
                 cell_line_to_tissue[cl_output] = str(tissue_key)
 
-        self.cell_line_effects = {}
-        for cl, mean in cell_line_means.items():
-            tissue_mean = tissue_means[cell_line_to_tissue[cl]]
-            self.cell_line_effects[cl] = mean - tissue_mean
+            self.cell_line_effects = {}
+            for cl, mean in cell_line_means.items():
+                tissue_mean = tissue_means[cell_line_to_tissue[cl]]
+                self.cell_line_effects[cl] = mean - tissue_mean
+        else:
+            self.tissue_effects = {}
+            self.cell_line_effects = {cl: (mean - self.dataset_mean) for cl, mean in cell_line_means.items()}
 
         drug_ids = drug_input.get_feature_matrix(view=DRUG_IDENTIFIER, identifiers=output.drug_ids)
         drug_means = {}
@@ -624,14 +632,20 @@ class NaiveMeanEffectsPredictor(NaiveModel):
         :param drug_input: Not used.
         :return: NumPy array of predicted responses.
         """
-        tissues = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=cell_line_ids)
         predictions = []
-        for cl, drug, tissue in zip(cell_line_ids, drug_ids, tissues, strict=True):
-            tissue_key = tissue.item() if isinstance(tissue, np.ndarray) else tissue
-            effect_tissue = self.tissue_effects.get(str(tissue_key), 0)
-            effect_cl = self.cell_line_effects.get(cl, 0)
-            effect_drug = self.drug_effects.get(drug, 0)
-            predictions.append(self.dataset_mean + effect_tissue + effect_cl + effect_drug)
+        if self.tissue_effects and TISSUE_IDENTIFIER in cell_line_input.view_names:
+            tissues = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=cell_line_ids)
+            for cl, drug, tissue in zip(cell_line_ids, drug_ids, tissues, strict=True):
+                tissue_key = tissue.item() if isinstance(tissue, np.ndarray) else tissue
+                effect_tissue = self.tissue_effects.get(str(tissue_key), 0)
+                effect_cl = self.cell_line_effects.get(cl, 0)
+                effect_drug = self.drug_effects.get(drug, 0)
+                predictions.append(self.dataset_mean + effect_tissue + effect_cl + effect_drug)
+        else:
+            for cl, drug in zip(cell_line_ids, drug_ids, strict=True):
+                effect_cl = self.cell_line_effects.get(cl, 0)
+                effect_drug = self.drug_effects.get(drug, 0)
+                predictions.append(self.dataset_mean + effect_cl + effect_drug)
         return np.array(predictions)
 
     def load_cell_line_features(self, data_path: str, dataset_name: str) -> FeatureDataset:
@@ -640,7 +654,7 @@ class NaiveMeanEffectsPredictor(NaiveModel):
 
         :param data_path: Path to the data.
         :param dataset_name: Name of the dataset.
-        :return: FeatureDataset containing the cell line IDs and tissue annotations.
+        :return: FeatureDataset containing the cell line IDs and tissue annotations, if available.
         """
         return load_cl_ids_and_tissues_from_csv(data_path, dataset_name)
 

--- a/drevalpy/models/baselines/naive_pred.py
+++ b/drevalpy/models/baselines/naive_pred.py
@@ -6,8 +6,8 @@ predicts the overall mean of the response, the NaiveCellLineMeanPredictor predic
 line, and the NaiveDrugMeanPredictor predicts the mean of the response per drug.
 The NaiveTissueMeanPredictor predicts the mean of the response per tissue.
 The NaiveTissueDrugMeanPredictor predicts the mean of the response per tissue-drug combination.
-The NaiveMeanEffectsPredictor predicts the response as the overall mean plus the cell line effect
-plus the drug effect and should be the strongest naive baseline.
+The NaiveMeanEffectsPredictor predicts the response as the overall mean plus tissue effect,
+cell line residual effect, and drug effect and should be the strongest naive baseline.
 
 """
 
@@ -19,7 +19,13 @@ import numpy as np
 from drevalpy.datasets.dataset import DrugResponseDataset, FeatureDataset
 from drevalpy.datasets.utils import CELL_LINE_IDENTIFIER, DRUG_IDENTIFIER, TISSUE_IDENTIFIER
 from drevalpy.models.drp_model import DRPModel
-from drevalpy.models.utils import load_cl_ids_from_csv, load_drug_ids_from_csv, load_tissues_from_csv, unique
+from drevalpy.models.utils import (
+    load_cl_ids_and_tissues_from_csv,
+    load_cl_ids_from_csv,
+    load_drug_ids_from_csv,
+    load_tissues_from_csv,
+    unique,
+)
 
 
 class NaiveModel(DRPModel):
@@ -63,6 +69,7 @@ class NaiveModel(DRPModel):
             "tissue_drug_means",
             "cell_line_effects",
             "drug_effects",
+            "tissue_effects",
         ]:
             if hasattr(self, attr):
                 config[attr] = getattr(self, attr)
@@ -90,6 +97,7 @@ class NaiveModel(DRPModel):
             "tissue_drug_means",
             "cell_line_effects",
             "drug_effects",
+            "tissue_effects",
         ]:
             if attr in config:
                 setattr(instance, attr, config[attr])
@@ -498,26 +506,29 @@ class NaiveMeanEffectsPredictor(NaiveModel):
     ANOVA-like predictor model.
 
     Predicts the response as:
-    response = overall_mean + cell_line_effect + drug_effect.
+    response = overall_mean + tissue_effect + cell_line_residual_effect + drug_effect.
 
     Here:
-        - cell_line_effect = (cell line mean - overall_mean)
+        - tissue_effect = (tissue mean - overall_mean)
+        - cell_line_residual_effect = (cell line mean - tissue mean for that cell line)
         - drug_effect = (drug mean - overall_mean)
 
-    This formulation ensures that the overall mean is not counted twice.
+    This formulation avoids double-counting tissue signal already captured by cell line means.
+    For unseen cell lines with a known tissue, the tissue effect provides a fallback.
     """
 
-    cell_line_views = [CELL_LINE_IDENTIFIER]
+    cell_line_views = [CELL_LINE_IDENTIFIER, TISSUE_IDENTIFIER]
     drug_views = [DRUG_IDENTIFIER]
 
     def __init__(self):
         """
         Initializes the NaiveMeanEffectsPredictor model.
 
-        The overall dataset mean, cell line effects, and drug effects are initialized to None
-        and empty dictionaries, respectively.
+        The overall dataset mean, tissue effects, cell line residual effects, and drug effects
+        are initialized to None and empty dictionaries, respectively.
         """
         super().__init__()
+        self.tissue_effects = {}
         self.cell_line_effects = {}
         self.drug_effects = {}
 
@@ -539,10 +550,10 @@ class NaiveMeanEffectsPredictor(NaiveModel):
         model_checkpoint_dir: str = "checkpoints",
     ) -> None:
         """
-        Trains with overall mean, cell line effects, and drug effects.
+        Trains with overall mean, tissue effects, cell line residual effects, and drug effects.
 
         :param output: Training dataset containing the response output.
-        :param cell_line_input: Feature dataset containing cell line IDs.
+        :param cell_line_input: Feature dataset containing cell line IDs and tissue annotations.
         :param drug_input: Feature dataset containing drug IDs. Must not be None.
         :param output_earlystopping: Not used.
         :param model_checkpoint_dir: Not used.
@@ -551,19 +562,40 @@ class NaiveMeanEffectsPredictor(NaiveModel):
         if drug_input is None:
             raise ValueError("drug_input (drug_id) is required for NaiveMeanEffectsPredictor.")
 
-        # Compute the overall mean response.
         self.dataset_mean = np.mean(output.response)
 
-        # Obtain cell line features.
+        tissues = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=output.cell_line_ids)
+        tissues = np.asarray(tissues).flatten()
+
+        tissue_means = {}
+        for tissue in np.unique(tissues):
+            tissue_key = str(tissue.item() if isinstance(tissue, np.ndarray) else tissue)
+            mask = tissues == tissue
+            responses_tissue = output.response[mask]
+            if len(responses_tissue) > 0:
+                tissue_means[tissue_key] = np.mean(responses_tissue)
+
+        self.tissue_effects = {
+            tissue: (mean - self.dataset_mean) for tissue, mean in tissue_means.items()
+        }
 
         cell_line_ids = cell_line_input.get_feature_matrix(view=CELL_LINE_IDENTIFIER, identifiers=output.cell_line_ids)
         cell_line_means = {}
+        cell_line_to_tissue = {}
         for cl_output, cl_feature in zip(unique(output.cell_line_ids), unique(cell_line_ids), strict=True):
-            responses_cl = output.response[cl_feature == output.cell_line_ids]
+            mask = cl_feature == output.cell_line_ids
+            responses_cl = output.response[mask]
             if len(responses_cl) > 0:
                 cell_line_means[cl_output] = np.mean(responses_cl)
+                tissue = tissues[mask][0]
+                tissue_key = tissue.item() if isinstance(tissue, np.ndarray) else tissue
+                cell_line_to_tissue[cl_output] = str(tissue_key)
 
-        # Obtain drug features.
+        self.cell_line_effects = {}
+        for cl, mean in cell_line_means.items():
+            tissue_mean = tissue_means[cell_line_to_tissue[cl]]
+            self.cell_line_effects[cl] = mean - tissue_mean
+
         drug_ids = drug_input.get_feature_matrix(view=DRUG_IDENTIFIER, identifiers=output.drug_ids)
         drug_means = {}
         for drug_output, drug_feature in zip(unique(output.drug_ids), unique(drug_ids), strict=True):
@@ -571,8 +603,6 @@ class NaiveMeanEffectsPredictor(NaiveModel):
             if len(responses_drug) > 0:
                 drug_means[drug_output] = np.mean(responses_drug)
 
-        # Compute the effects as deviations from the overall mean.
-        self.cell_line_effects = {cl: (mean - self.dataset_mean) for cl, mean in cell_line_means.items()}
         self.drug_effects = {drug: (mean - self.dataset_mean) for drug, mean in drug_means.items()}
 
     def predict(
@@ -586,22 +616,24 @@ class NaiveMeanEffectsPredictor(NaiveModel):
         Predicts responses for given cell line and drug pairs.
 
         The prediction is computed as:
-            prediction = overall_mean + cell_line_effect + drug_effect
+            prediction = overall_mean + tissue_effect + cell_line_residual_effect + drug_effect
 
-        If a cell line or drug has not been seen during training, their effect is set to zero.
+        If a cell line, tissue, or drug has not been seen during training, their effect is set to zero.
 
         :param cell_line_ids: Array of cell line IDs.
         :param drug_ids: Array of drug IDs.
-        :param cell_line_input: Not used.
+        :param cell_line_input: Feature dataset containing tissue annotations.
         :param drug_input: Not used.
         :return: NumPy array of predicted responses.
         """
+        tissues = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=cell_line_ids)
         predictions = []
-        for cl, drug in zip(cell_line_ids, drug_ids):
+        for cl, drug, tissue in zip(cell_line_ids, drug_ids, tissues, strict=True):
+            tissue_key = tissue.item() if isinstance(tissue, np.ndarray) else tissue
+            effect_tissue = self.tissue_effects.get(str(tissue_key), 0)
             effect_cl = self.cell_line_effects.get(cl, 0)
             effect_drug = self.drug_effects.get(drug, 0)
-            # ANOVA-based prediction: overall mean + cell line effect + drug effect.
-            predictions.append(self.dataset_mean + effect_cl + effect_drug)
+            predictions.append(self.dataset_mean + effect_tissue + effect_cl + effect_drug)
         return np.array(predictions)
 
     def load_cell_line_features(self, data_path: str, dataset_name: str) -> FeatureDataset:
@@ -610,9 +642,9 @@ class NaiveMeanEffectsPredictor(NaiveModel):
 
         :param data_path: Path to the data.
         :param dataset_name: Name of the dataset.
-        :return: FeatureDataset containing the cell line IDs.
+        :return: FeatureDataset containing the cell line IDs and tissue annotations.
         """
-        return load_cl_ids_from_csv(data_path, dataset_name)
+        return load_cl_ids_and_tissues_from_csv(data_path, dataset_name)
 
     def load_drug_features(self, data_path: str, dataset_name: str) -> FeatureDataset:
         """

--- a/drevalpy/models/utils.py
+++ b/drevalpy/models/utils.py
@@ -80,14 +80,17 @@ def load_tissues_from_csv(path: str, dataset_name: str) -> FeatureDataset:
 
 def load_cl_ids_and_tissues_from_csv(path: str, dataset_name: str) -> FeatureDataset:
     """
-    Load cell line ids and tissue annotations from csv file.
+    Load cell line ids and optional tissue annotations from csv file.
 
     :param path: path to the data, e.g., data/
     :param dataset_name: name of the dataset, e.g., GDSC2
-    :returns: FeatureDataset with cell line ids and tissue annotations
+    :returns: FeatureDataset with cell line ids and tissue annotations, if available
     """
     cl_ids = load_cl_ids_from_csv(path, dataset_name)
-    cl_ids.add_features(load_tissues_from_csv(path, dataset_name))
+    try:
+        cl_ids.add_features(load_tissues_from_csv(path, dataset_name))
+    except KeyError:
+        pass
     return cl_ids
 
 

--- a/drevalpy/models/utils.py
+++ b/drevalpy/models/utils.py
@@ -78,6 +78,19 @@ def load_tissues_from_csv(path: str, dataset_name: str) -> FeatureDataset:
     )
 
 
+def load_cl_ids_and_tissues_from_csv(path: str, dataset_name: str) -> FeatureDataset:
+    """
+    Load cell line ids and tissue annotations from csv file.
+
+    :param path: path to the data, e.g., data/
+    :param dataset_name: name of the dataset, e.g., GDSC2
+    :returns: FeatureDataset with cell line ids and tissue annotations
+    """
+    cl_ids = load_cl_ids_from_csv(path, dataset_name)
+    cl_ids.add_features(load_tissues_from_csv(path, dataset_name))
+    return cl_ids
+
+
 def load_and_select_gene_features(
     feature_type: str,
     gene_list: str | None,

--- a/tests/models/test_baselines.py
+++ b/tests/models/test_baselines.py
@@ -91,7 +91,7 @@ def test_naive_mean_effects_predictor_tissue_decomposition() -> None:
 
     with tempfile.TemporaryDirectory() as model_dir:
         model.save(model_dir)
-        loaded = NaiveMeanEffectsPredictor.load(model_dir)
+        loaded = cast(NaiveMeanEffectsPredictor, NaiveMeanEffectsPredictor.load(model_dir))
         assert loaded.tissue_effects == model.tissue_effects
         loaded_preds = loaded.predict(
             cell_line_ids=np.array(["CL1"]),

--- a/tests/models/test_baselines.py
+++ b/tests/models/test_baselines.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 from sklearn.linear_model import ElasticNet, Ridge
 
-from drevalpy.datasets.dataset import DrugResponseDataset
-from drevalpy.datasets.utils import TISSUE_IDENTIFIER
+from drevalpy.datasets.dataset import DrugResponseDataset, FeatureDataset
+from drevalpy.datasets.utils import CELL_LINE_IDENTIFIER, DRUG_IDENTIFIER, TISSUE_IDENTIFIER
 from drevalpy.evaluation import evaluate
 from drevalpy.experiment import cross_study_prediction
 from drevalpy.models import (
@@ -22,6 +22,86 @@ from drevalpy.models import (
 )
 from drevalpy.models.baselines.sklearn_models import RandomForest, SklearnModel
 from drevalpy.models.drp_model import DRPModel
+
+
+def test_naive_mean_effects_predictor_tissue_decomposition() -> None:
+    """Test tissue-aware decomposition in NaiveMeanEffectsPredictor."""
+    cell_lines = np.array(["CL1", "CL1", "CL2", "CL2", "CL3", "CL3"])
+    drugs = np.array(["D1", "D2", "D1", "D2", "D1", "D2"])
+    response = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+    output = DrugResponseDataset(
+        response=response,
+        cell_line_ids=cell_lines,
+        drug_ids=drugs,
+    )
+    cell_line_input = FeatureDataset(
+        features={
+            "CL1": {
+                CELL_LINE_IDENTIFIER: np.array(["CL1"]),
+                TISSUE_IDENTIFIER: np.array(["Lung"]),
+            },
+            "CL2": {
+                CELL_LINE_IDENTIFIER: np.array(["CL2"]),
+                TISSUE_IDENTIFIER: np.array(["Lung"]),
+            },
+            "CL3": {
+                CELL_LINE_IDENTIFIER: np.array(["CL3"]),
+                TISSUE_IDENTIFIER: np.array(["Blood"]),
+            },
+        }
+    )
+    drug_input = FeatureDataset(
+        features={
+            "D1": {DRUG_IDENTIFIER: np.array(["D1"])},
+            "D2": {DRUG_IDENTIFIER: np.array(["D2"])},
+        }
+    )
+
+    model = NaiveMeanEffectsPredictor()
+    model.train(output=output, cell_line_input=cell_line_input, drug_input=drug_input)
+
+    dataset_mean = np.mean(response)
+    assert model.dataset_mean == dataset_mean
+
+    lung_mean = np.mean([1.0, 2.0, 3.0, 4.0])
+    blood_mean = np.mean([5.0, 6.0])
+    assert model.tissue_effects["Lung"] == pytest.approx(lung_mean - dataset_mean)
+    assert model.tissue_effects["Blood"] == pytest.approx(blood_mean - dataset_mean)
+
+    cl1_mean = np.mean([1.0, 2.0])
+    cl2_mean = np.mean([3.0, 4.0])
+    cl3_mean = np.mean([5.0, 6.0])
+    assert model.cell_line_effects["CL1"] == pytest.approx(cl1_mean - lung_mean)
+    assert model.cell_line_effects["CL2"] == pytest.approx(cl2_mean - lung_mean)
+    assert model.cell_line_effects["CL3"] == pytest.approx(cl3_mean - blood_mean)
+
+    preds = model.predict(
+        cell_line_ids=np.array(["CL1", "CL2", "CL3"]),
+        drug_ids=np.array(["D1", "D2", "D1"]),
+        cell_line_input=cell_line_input,
+    )
+    for i, (cl, drug) in enumerate(zip(["CL1", "CL2", "CL3"], ["D1", "D2", "D1"], strict=True)):
+        tissue_arr = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=np.array([cl]))
+        tissue_key = str(tissue_arr[0].item() if isinstance(tissue_arr[0], np.ndarray) else tissue_arr[0])
+        expected = (
+            dataset_mean
+            + model.tissue_effects[tissue_key]
+            + model.cell_line_effects[cl]
+            + model.drug_effects[drug]
+        )
+        assert preds[i] == pytest.approx(expected)
+
+    with tempfile.TemporaryDirectory() as model_dir:
+        model.save(model_dir)
+        loaded = NaiveMeanEffectsPredictor.load(model_dir)
+        assert loaded.tissue_effects == model.tissue_effects
+        loaded_preds = loaded.predict(
+            cell_line_ids=np.array(["CL1"]),
+            drug_ids=np.array(["D1"]),
+            cell_line_input=cell_line_input,
+        )
+        assert loaded_preds[0] == pytest.approx(preds[0])
 
 
 @pytest.mark.parametrize("max_depth_input, expected", [(5, 5), (10, 10), (30, 30), ("None", None)])

--- a/tests/models/test_baselines.py
+++ b/tests/models/test_baselines.py
@@ -101,6 +101,47 @@ def test_naive_mean_effects_predictor_tissue_decomposition() -> None:
         assert loaded_preds[0] == pytest.approx(preds[0])
 
 
+def test_naive_mean_effects_predictor_without_tissue_matches_previous_decomposition() -> None:
+    """Test NaiveMeanEffectsPredictor falls back to cell-line and drug effects without tissue."""
+    cell_lines = np.array(["CL1", "CL1", "CL2", "CL2"])
+    drugs = np.array(["D1", "D2", "D1", "D2"])
+    response = np.array([1.0, 2.0, 5.0, 8.0])
+    output = DrugResponseDataset(response=response, cell_line_ids=cell_lines, drug_ids=drugs)
+    cell_line_input = FeatureDataset(
+        features={
+            "CL1": {CELL_LINE_IDENTIFIER: np.array(["CL1"])},
+            "CL2": {CELL_LINE_IDENTIFIER: np.array(["CL2"])},
+        }
+    )
+    drug_input = FeatureDataset(
+        features={
+            "D1": {DRUG_IDENTIFIER: np.array(["D1"])},
+            "D2": {DRUG_IDENTIFIER: np.array(["D2"])},
+        }
+    )
+
+    model = NaiveMeanEffectsPredictor()
+    model.train(output=output, cell_line_input=cell_line_input, drug_input=drug_input)
+
+    dataset_mean = np.mean(response)
+    assert model.tissue_effects == {}
+    assert model.cell_line_effects["CL1"] == pytest.approx(np.mean([1.0, 2.0]) - dataset_mean)
+    assert model.cell_line_effects["CL2"] == pytest.approx(np.mean([5.0, 8.0]) - dataset_mean)
+
+    preds = model.predict(
+        cell_line_ids=np.array(["CL1", "CL2"]),
+        drug_ids=np.array(["D1", "D2"]),
+        cell_line_input=cell_line_input,
+    )
+    expected = np.array(
+        [
+            dataset_mean + model.cell_line_effects["CL1"] + model.drug_effects["D1"],
+            dataset_mean + model.cell_line_effects["CL2"] + model.drug_effects["D2"],
+        ]
+    )
+    np.testing.assert_allclose(preds, expected)
+
+
 @pytest.mark.parametrize("max_depth_input, expected", [(5, 5), (10, 10), (30, 30), ("None", None)])
 def test_random_forest_respects_max_depth(max_depth_input, expected) -> None:
     """Ensure RandomForest forwards max_depth to the underlying RandomForestRegressor.

--- a/tests/models/test_baselines.py
+++ b/tests/models/test_baselines.py
@@ -85,10 +85,7 @@ def test_naive_mean_effects_predictor_tissue_decomposition() -> None:
         tissue_arr = cell_line_input.get_feature_matrix(view=TISSUE_IDENTIFIER, identifiers=np.array([cl]))
         tissue_key = str(tissue_arr[0].item() if isinstance(tissue_arr[0], np.ndarray) else tissue_arr[0])
         expected = (
-            dataset_mean
-            + model.tissue_effects[tissue_key]
-            + model.cell_line_effects[cl]
-            + model.drug_effects[drug]
+            dataset_mean + model.tissue_effects[tissue_key] + model.cell_line_effects[cl] + model.drug_effects[drug]
         )
         assert preds[i] == pytest.approx(expected)
 

--- a/tests/test_drp_model.py
+++ b/tests/test_drp_model.py
@@ -9,12 +9,13 @@ import pandas as pd
 import pytest
 
 from drevalpy.datasets.dataset import DrugResponseDataset
-from drevalpy.datasets.utils import DRUG_IDENTIFIER, TISSUE_IDENTIFIER
+from drevalpy.datasets.utils import CELL_LINE_IDENTIFIER, DRUG_IDENTIFIER, TISSUE_IDENTIFIER
 from drevalpy.models import MODEL_FACTORY
 from drevalpy.models.utils import (
     get_multiomics_feature_dataset,
     iterate_features,
     load_and_select_gene_features,
+    load_cl_ids_and_tissues_from_csv,
     load_cl_ids_from_csv,
     load_drug_fingerprint_features,
     load_drug_ids_from_csv,
@@ -89,6 +90,36 @@ def test_load_tissues_from_csv() -> None:
             assert isinstance(tissue_value, np.ndarray)
             assert tissue_value.shape == (1,)
             assert tissue_value[0] == expected_tissue
+
+
+def test_load_cl_ids_and_tissues_from_csv() -> None:
+    """Test loading cell line ids and tissues from a CSV file."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.mkdir(os.path.join(temp_dir, "GDSC1_small"))
+        temp_file = os.path.join(temp_dir, "GDSC1_small", "cell_line_names.csv")
+        with open(temp_file, "w") as f:
+            f.write(
+                "cellosaurus_id,cell_line_name,tissue\n"
+                "CVCL_X481,201T,lung\n"
+                "CVCL_1045,22Rv1,breast\n"
+            )
+
+        features = load_cl_ids_and_tissues_from_csv(temp_dir, "GDSC1_small")
+        assert len(features.features) == 2
+        assert features.features["201T"][TISSUE_IDENTIFIER][0] == "lung"
+        assert features.features["22Rv1"][CELL_LINE_IDENTIFIER][0] == "22Rv1"
+
+
+def test_load_cl_ids_and_tissues_from_csv_missing_tissue_column() -> None:
+    """Test that missing tissue column raises KeyError."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.mkdir(os.path.join(temp_dir, "GDSC1_small"))
+        temp_file = os.path.join(temp_dir, "GDSC1_small", "cell_line_names.csv")
+        with open(temp_file, "w") as f:
+            f.write("cellosaurus_id,cell_line_name\nCVCL_X481,201T\n")
+
+        with pytest.raises(KeyError, match="tissue"):
+            load_cl_ids_and_tissues_from_csv(temp_dir, "GDSC1_small")
 
 
 def _write_gene_list(temp_dir: tempfile.TemporaryDirectory, gene_list: Optional[str] = None) -> None:

--- a/tests/test_drp_model.py
+++ b/tests/test_drp_model.py
@@ -98,11 +98,7 @@ def test_load_cl_ids_and_tissues_from_csv() -> None:
         os.mkdir(os.path.join(temp_dir, "GDSC1_small"))
         temp_file = os.path.join(temp_dir, "GDSC1_small", "cell_line_names.csv")
         with open(temp_file, "w") as f:
-            f.write(
-                "cellosaurus_id,cell_line_name,tissue\n"
-                "CVCL_X481,201T,lung\n"
-                "CVCL_1045,22Rv1,breast\n"
-            )
+            f.write("cellosaurus_id,cell_line_name,tissue\n" "CVCL_X481,201T,lung\n" "CVCL_1045,22Rv1,breast\n")
 
         features = load_cl_ids_and_tissues_from_csv(temp_dir, "GDSC1_small")
         assert len(features.features) == 2

--- a/tests/test_drp_model.py
+++ b/tests/test_drp_model.py
@@ -107,15 +107,17 @@ def test_load_cl_ids_and_tissues_from_csv() -> None:
 
 
 def test_load_cl_ids_and_tissues_from_csv_missing_tissue_column() -> None:
-    """Test that missing tissue column raises KeyError."""
+    """Test that missing tissue column falls back to cell line ids."""
     with tempfile.TemporaryDirectory() as temp_dir:
         os.mkdir(os.path.join(temp_dir, "GDSC1_small"))
         temp_file = os.path.join(temp_dir, "GDSC1_small", "cell_line_names.csv")
         with open(temp_file, "w") as f:
             f.write("cellosaurus_id,cell_line_name\nCVCL_X481,201T\n")
 
-        with pytest.raises(KeyError, match="tissue"):
-            load_cl_ids_and_tissues_from_csv(temp_dir, "GDSC1_small")
+        features = load_cl_ids_and_tissues_from_csv(temp_dir, "GDSC1_small")
+        assert len(features.features) == 1
+        assert features.features["201T"][CELL_LINE_IDENTIFIER][0] == "201T"
+        assert TISSUE_IDENTIFIER not in features.features["201T"]
 
 
 def _write_gene_list(temp_dir: tempfile.TemporaryDirectory, gene_list: Optional[str] = None) -> None:


### PR DESCRIPTION
## Summary
- Add tissue-aware decomposition to `NaiveMeanEffectsPredictor` using tissue effects plus cell-line residual effects.
- Keep the previous mean-effects behavior when tissue annotations are unavailable: the tissue term contributes zero and cell-line effects are computed against the global mean.
- Load cell-line IDs and tissue annotations together when tissue metadata exists, while allowing datasets without tissue metadata to continue running outside LTO.
- Cover decomposition, persistence, no-tissue fallback, and combined feature loading with focused tests.

## NME terms by split mode

The tissue-aware NME now predicts:

```text
prediction = overall_mean + tissue_effect + cell_line_residual_effect + drug_effect
```

Legend: `✓` active, `✗` inactive, `?` maybe active depending on whether the identifier was seen in training.

| Split mode | Overall mean | Tissue effect | Cell-line residual effect | Drug effect |
| --- | --- | --- | --- | --- |
| LPO | ✓ | ? | ? | ? |
| LCO | ✓ | ? * | ✗ | ? |
| LDO | ✓ | ? | ? | ✗ |
| LTO | ✓ | ✗ | ✗ | ? |

* Most relevant change: in LCO, the held-out cell line has no cell-line residual effect. Without the tissue term, NME would only use the overall mean and drug effect. The tissue term lets NME capture the mean tissue effect for held-out cell lines when that tissue was observed during training.

The cell-line term is a residual effect rather than the original cell-line effect when tissue is available: `cell_line_mean - tissue_mean_for_cell_line`. This keeps the known-cell-line contribution equivalent to the previous decomposition while preventing the tissue-level signal from being counted twice, once through the tissue effect and again through the cell-line effect. When tissue is unavailable, the tissue term is zero and the cell-line effect falls back to the previous definition: `cell_line_mean - overall_mean`.

## Test plan
- Added focused decomposition coverage that verifies the tissue effect, the cell-line residual effect, the composed prediction, and save/load persistence for the tissue-aware mean-effects baseline.
- Added no-tissue fallback coverage that verifies NME reproduces the previous overall mean + cell-line effect + drug effect decomposition when tissue annotations are absent.
- Added loader coverage that verifies the combined cell-line/tissue feature dataset contains both views when tissue exists and falls back to cell-line IDs only when tissue metadata is missing.
- Re-ran static typing and smoke checks for the tissue-aware and no-tissue fallback paths.
- Confirmed the full PR CI was green before the latest fallback commit; CI has been re-triggered for this update.