### PR TITLE
fix: always reduce the early stopping set to available features in train_final_model

### DIFF
--- a/drevalpy/experiment.py
+++ b/drevalpy/experiment.py
@@ -1629,16 +1629,20 @@ def train_final_model(
     if len(train_dataset) < len_train_before:
         print(f"Reduced training dataset from {len_train_before} to {len(train_dataset)}, due to missing features")
 
+    # The early stopping set has to be reduced to the available features in every case, not only when a
+    # response transformation is used, otherwise models are handed cell lines without a feature row.
+    if early_stopping_dataset is not None:
+        len_early_stopping_before = len(early_stopping_dataset)
+        early_stopping_dataset.reduce_to(cell_line_ids=cell_lines_to_keep, drug_ids=drugs_to_keep)
+        if len(early_stopping_dataset) < len_early_stopping_before:
+            print(
+                f"Reduced early stopping dataset from {len_early_stopping_before} to "
+                f"{len(early_stopping_dataset)}, due to missing features"
+            )
+
     if response_transformation:
         train_dataset.fit_transform(response_transformation)
         if early_stopping_dataset is not None:
-            len_early_stopping_before = len(early_stopping_dataset)
-            early_stopping_dataset.reduce_to(cell_line_ids=cell_lines_to_keep, drug_ids=drugs_to_keep)
-            if len(early_stopping_dataset) < len_early_stopping_before:
-                print(
-                    f"Reduced early stopping dataset from {len_early_stopping_before} to "
-                    f"{len(early_stopping_dataset)}, due to missing features"
-                )
             early_stopping_dataset.transform(response_transformation)
 
     drug_features = drug_features.copy() if drug_features is not None else None

--- a/drevalpy/experiment.py
+++ b/drevalpy/experiment.py
@@ -1555,7 +1555,7 @@ def generate_data_saving_path(model_name, drug_id, result_path, suffix) -> str:
 def train_final_model(
     model_class: type[DRPModel],
     full_dataset: DrugResponseDataset,
-    response_transformation: TransformerMixin,
+    response_transformation: TransformerMixin | None,
     path_data: str,
     model_checkpoint_dir: str,
     metric: str,
@@ -1578,7 +1578,7 @@ def train_final_model(
 
     :param model_class: model to use
     :param full_dataset: full training dataset (union of outer folds)
-    :param response_transformation: sklearn scaler used for response normalization
+    :param response_transformation: sklearn scaler used for response normalization, None for no transformation
     :param path_data: path to data directory
     :param model_checkpoint_dir: checkpoint dir for intermediate tuning models
     :param metric: metric for tuning, e.g., "RMSE"

--- a/tests/test_final_model_early_stopping.py
+++ b/tests/test_final_model_early_stopping.py
@@ -1,0 +1,176 @@
+"""Regression test: train_final_model must reduce the early stopping set to available features."""
+
+import numpy as np
+
+from drevalpy.datasets.dataset import DrugResponseDataset, FeatureDataset, split_early_stopping_data
+from drevalpy.experiment import make_train_val_split, train_final_model
+from drevalpy.models.drp_model import DRPModel
+
+_N_CELL_LINES = 40
+_N_DRUGS = 10
+#: Only the first half of the cell lines has a feature row, the rest has to be dropped from every split.
+_N_WITH_FEATURES = _N_CELL_LINES // 2
+
+
+def _toy_response() -> DrugResponseDataset:
+    """
+    Build a fully crossed toy response dataset.
+
+    :returns: dataset with _N_CELL_LINES x _N_DRUGS rows
+    """
+    cell_line_ids = np.repeat([f"CL{i}" for i in range(_N_CELL_LINES)], _N_DRUGS)
+    drug_ids = np.tile([f"D{j}" for j in range(_N_DRUGS)], _N_CELL_LINES)
+    rng = np.random.default_rng(0)
+    return DrugResponseDataset(
+        response=rng.normal(size=len(cell_line_ids)),
+        cell_line_ids=cell_line_ids,
+        drug_ids=drug_ids,
+        dataset_name="TOY_ES",
+    )
+
+
+def _toy_features() -> FeatureDataset:
+    """
+    Build cell line features that cover only the first half of the cell lines.
+
+    :returns: FeatureDataset with a gene_expression view
+    """
+    rng = np.random.default_rng(1)
+    return FeatureDataset(features={f"CL{i}": {"gene_expression": rng.normal(size=5)} for i in range(_N_WITH_FEATURES)})
+
+
+class _EarlyStoppingModel(DRPModel):
+    """Minimal early stopping model that only records what train() was handed."""
+
+    cell_line_views = ["gene_expression"]
+    drug_views: list[str] = []
+    early_stopping = True
+
+    #: unique early stopping cell line ids seen by train(), read by the test
+    seen_early_stopping_ids: np.ndarray | None = None
+
+    @classmethod
+    def get_model_name(cls) -> str:
+        """
+        Returns the model name.
+
+        :returns: name of this test model
+        """
+        return "EarlyStoppingModel"
+
+    @classmethod
+    def get_hyperparameter_set(cls) -> list[dict]:
+        """
+        Returns a single empty hyperparameter set, there is no hyperparameters.yaml for a test model.
+
+        :returns: list with one empty hyperparameter dict
+        """
+        return [{}]
+
+    def build_model(self, hyperparameters: dict) -> None:
+        """
+        Stores the hyperparameters.
+
+        :param hyperparameters: hyperparameters to use
+        """
+        self.hyperparameters = hyperparameters
+
+    def load_cell_line_features(self, data_path: str, dataset_name: str) -> FeatureDataset:
+        """
+        Returns the toy features, ignoring path and dataset name.
+
+        :param data_path: unused
+        :param dataset_name: unused
+        :returns: toy cell line features
+        """
+        return _toy_features()
+
+    def load_drug_features(self, data_path: str, dataset_name: str) -> FeatureDataset | None:
+        """
+        This model does not use drug features.
+
+        :param data_path: unused
+        :param dataset_name: unused
+        :returns: None
+        """
+        return None
+
+    def train(
+        self,
+        output: DrugResponseDataset,
+        cell_line_input: FeatureDataset,
+        drug_input: FeatureDataset | None = None,
+        output_earlystopping: DrugResponseDataset | None = None,
+        model_checkpoint_dir: str = "checkpoints",
+    ) -> None:
+        """
+        Fetches the feature matrices exactly like a real model does, which asserts on missing ids.
+
+        :param output: training dataset
+        :param cell_line_input: cell line features
+        :param drug_input: unused
+        :param output_earlystopping: early stopping dataset
+        :param model_checkpoint_dir: unused
+        """
+        cell_line_input.get_feature_matrix(view="gene_expression", identifiers=output.cell_line_ids)
+        if output_earlystopping is not None:
+            cell_line_input.get_feature_matrix(view="gene_expression", identifiers=output_earlystopping.cell_line_ids)
+            type(self).seen_early_stopping_ids = np.unique(output_earlystopping.cell_line_ids)
+
+    def predict(
+        self,
+        cell_line_ids: np.ndarray,
+        drug_ids: np.ndarray,
+        cell_line_input: FeatureDataset,
+        drug_input: FeatureDataset | None = None,
+    ) -> np.ndarray:
+        """
+        Returns zeros.
+
+        :param cell_line_ids: cell line ids to predict for
+        :param drug_ids: unused
+        :param cell_line_input: unused
+        :param drug_input: unused
+        :returns: zero predictions
+        """
+        return np.zeros(len(cell_line_ids))
+
+    def save(self, directory: str) -> None:
+        """
+        Nothing to persist for a test model.
+
+        :param directory: target directory
+        """
+
+
+def test_final_model_reduces_early_stopping_set(tmp_path):
+    """
+    Without a response transformation the early stopping set must still be reduced to available features.
+
+    :param tmp_path: pytest temporary path fixture
+    """
+    with_features = set(_toy_features().identifiers)
+
+    # Precondition: with the splitting parameters train_final_model uses, the raw early stopping set
+    # really does contain cell lines without features, otherwise the test would be vacuous.
+    _, validation = make_train_val_split(_toy_response(), test_mode="LPO", val_ratio=0.1)
+    _, raw_early_stopping = split_early_stopping_data(validation, test_mode="LPO")
+    assert not set(raw_early_stopping.cell_line_ids).issubset(with_features)
+
+    _EarlyStoppingModel.seen_early_stopping_ids = None
+    train_final_model(
+        model_class=_EarlyStoppingModel,
+        full_dataset=_toy_response(),
+        response_transformation=None,
+        path_data="unused",
+        model_checkpoint_dir=str(tmp_path / "checkpoints"),
+        metric="RMSE",
+        final_model_path=str(tmp_path / "final_model"),
+        test_mode="LPO",
+        val_ratio=0.1,
+        hyperparameter_tuning=False,
+    )
+
+    seen = _EarlyStoppingModel.seen_early_stopping_ids
+    assert seen is not None and len(seen) > 0
+    assert set(seen).issubset(with_features)


### PR DESCRIPTION
# PR Checklist for all PRs

- [x] This comment contains a description of changes (with reason)
- [ ] Referenced issue is linked — no existing issue, found while running final models with early stopping
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated — no user-facing API change, so nothing to update

### Changes

### Bug fixes

In `train_final_model`, the training set is reduced to the cell lines and drugs that actually have
features, and a matching reduction exists for the early stopping set. That second reduction, however,
sits **inside** `if response_transformation:`:

```python
if response_transformation:
    train_dataset.fit_transform(response_transformation)
    if early_stopping_dataset is not None:
        early_stopping_dataset.reduce_to(cell_line_ids=cell_lines_to_keep, drug_ids=drugs_to_keep)
        ...
        early_stopping_dataset.transform(response_transformation)
```

So whenever a final model is trained with early stopping but **without** a response transformation
(the default), the early stopping set is never reduced. The model then receives early stopping cell
lines / drugs that have no feature row, while the training set has already been filtered. Depending
on the model this surfaces as a `KeyError` on the missing identifier, or as a silently wrong early
stopping signal.

The reduction is not conditional on the transformation — it depends only on which features are
available — so this moves it out of the `if` block. The transformation call stays where it was.

Tests: `tests/test_final_model_early_stopping.py` drives `train_final_model` with a minimal early
stopping model whose features cover only half of the cell lines and with `response_transformation=None`.
It first asserts the precondition (the raw early stopping split really does contain cell lines without
features) so the test cannot go vacuous, then asserts that `train()` only ever sees cell lines that
have a feature row. Against the current `development` the test fails; with the fix it passes.

The full suite is green locally (219 passed).

### New features

### Maintenance

---

### Follow-up commit: `response_transformation` annotation

The `typeguard` session flagged the regression test, because `train_final_model` was annotated
`response_transformation: TransformerMixin` — without `| None`. The test has to pass `None`, since the
bug only occurs on the path *without* a response transformation.

The annotation is simply wrong, and it is the only one of the twelve `response_transformation`
parameters in `experiment.py` that lacks `| None`:

* the only internal caller, `experiment.py:463`, forwards `run_suite`'s `response_transformation:
  TransformerMixin | None = None`
* `get_response_transformation` is declared `-> TransformerMixin | None` and returns `None` for `"None"`
* the body of `train_final_model` itself guards with `if response_transformation:`

`mypy` cannot catch this: sklearn ships no type stubs, so `TransformerMixin` is `Any` and passing `None`
is unremarkable. Only the runtime check in the `typeguard` session sees it. The second commit widens the
annotation to `TransformerMixin | None` and updates the docstring; no behaviour changes.
