### PR TITLE
feat: make the gene list of single-view sklearn models configurable

### DIFF
--- a/drevalpy/models/baselines/sklearn_models.py
+++ b/drevalpy/models/baselines/sklearn_models.py
@@ -30,6 +30,9 @@ class SklearnModel(DRPModel):
 
     cell_line_views = []
     drug_views = []
+    #: Gene list used to subset gene_expression. Overridable via the "gene_list" hyperparameter.
+    #: The default reproduces the previously hard-coded behaviour.
+    gene_list: str | None = "landmark_genes_reduced"
 
     def __init__(self):
         """
@@ -81,6 +84,9 @@ class SklearnModel(DRPModel):
         self.hyperparameters = hyperparameters
         self.cell_line_views = _get_view_as_list(hyperparameters.get("cell_line_views", ["gene_expression"]))
         self.drug_views = _get_view_as_list(hyperparameters.get("drug_views", ["fingerprints"]))
+        # Kept in self.hyperparameters, so save()/load() carry it and predict() uses the same gene
+        # space the model was trained on.
+        self.gene_list = hyperparameters.get("gene_list", type(self).gene_list)
 
         # proteomics features are not supported for all models
         if "proteomics" in self.cell_line_views:
@@ -110,7 +116,9 @@ class SklearnModel(DRPModel):
         :param dataset_name: Name of the dataset
         :returns: FeatureDataset containing the cell line features
         """
-        return load_single_cell_line_view(self.cell_line_views, data_path, dataset_name, self.get_model_name())
+        return load_single_cell_line_view(
+            self.cell_line_views, data_path, dataset_name, self.get_model_name(), gene_list=self.gene_list
+        )
 
     def load_drug_features(self, data_path: str, dataset_name: str) -> FeatureDataset | None:
         """

--- a/drevalpy/models/utils.py
+++ b/drevalpy/models/utils.py
@@ -543,17 +543,20 @@ def load_single_cell_line_view(
     data_path: str,
     dataset_name: str,
     model_name: str,
+    gene_list: str | None = "landmark_genes_reduced",
 ) -> FeatureDataset:
     """
     Load cell line features for a single-view model.
 
-    If the view is "gene_expression", the landmark_genes_reduced list is used for subsetting.
-    Otherwise, the whole CSV is loaded.
+    If the view is "gene_expression", ``gene_list`` is used for subsetting. Otherwise, the whole CSV
+    is loaded.
 
     :param cell_line_views: list of cell line views (must have exactly one element)
     :param data_path: path to the data, e.g., data/
     :param dataset_name: name of the dataset, e.g., GDSC1
     :param model_name: name of the model, used for error messages
+    :param gene_list: gene list used to subset gene_expression, e.g., drug_target_genes_all_drugs.
+        None loads all genes. The default reproduces the previously hard-coded behaviour.
     :returns: FeatureDataset containing the cell line features
     :raises ValueError: if cell_line_views is empty or has more than one element
     """
@@ -569,7 +572,7 @@ def load_single_cell_line_view(
     if "gene_expression" in cell_line_views:
         return load_and_select_gene_features(
             feature_type="gene_expression",
-            gene_list="landmark_genes_reduced",
+            gene_list=gene_list,
             data_path=data_path,
             dataset_name=dataset_name,
         )

--- a/tests/test_sklearn_gene_list.py
+++ b/tests/test_sklearn_gene_list.py
@@ -3,7 +3,7 @@
 import pytest
 
 from drevalpy.models import MODEL_FACTORY
-from drevalpy.models.baselines.sklearn_models import SklearnModel
+from drevalpy.models.baselines.sklearn_models import ElasticNetModel, SklearnModel
 from drevalpy.models.utils import load_single_cell_line_view
 
 _GENE_EXPRESSION = (
@@ -95,7 +95,10 @@ def test_load_single_cell_line_view_gene_list_none_loads_all_genes(gene_list_dat
 
 def test_sklearn_model_gene_list_default() -> None:
     """Without the hyperparameter the model keeps the class default."""
-    model = MODEL_FACTORY["ElasticNet"]()
+    # The concrete class is used directly so mypy sees the SklearnModel attributes; MODEL_FACTORY
+    # returns DRPModel. This asserts that the registered model really is that class.
+    assert MODEL_FACTORY["ElasticNet"] is ElasticNetModel
+    model = ElasticNetModel()
     model.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2})
     assert model.gene_list == SklearnModel.gene_list == "landmark_genes_reduced"
 
@@ -106,7 +109,7 @@ def test_sklearn_model_gene_list_hyperparameter(gene_list_data_dir) -> None:
 
     :param gene_list_data_dir: path to the temporary data directory
     """
-    model = MODEL_FACTORY["ElasticNet"]()
+    model = ElasticNetModel()
     model.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2, "gene_list": "drug_target_genes_all_drugs"})
     assert model.gene_list == "drug_target_genes_all_drugs"
     # It stays in the hyperparameters, so save()/load() carry it over to predict().
@@ -124,14 +127,14 @@ def test_sklearn_model_gene_list_does_not_leak_between_instances(gene_list_data_
 
     :param gene_list_data_dir: path to the temporary data directory
     """
-    configured = MODEL_FACTORY["ElasticNet"]()
+    configured = ElasticNetModel()
     configured.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2, "gene_list": None})
     assert configured.gene_list is None
     assert sorted(_gene_names(configured.load_cell_line_features(gene_list_data_dir, "GDSC1_small"))) == sorted(
         _ALL_GENES
     )
 
-    default = MODEL_FACTORY["ElasticNet"]()
+    default = ElasticNetModel()
     default.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2})
     assert sorted(_gene_names(default.load_cell_line_features(gene_list_data_dir, "GDSC1_small"))) == sorted(
         _LANDMARK_GENES

--- a/tests/test_sklearn_gene_list.py
+++ b/tests/test_sklearn_gene_list.py
@@ -1,0 +1,138 @@
+"""Tests for the configurable gene list of single-view sklearn models."""
+
+import pytest
+
+from drevalpy.models import MODEL_FACTORY
+from drevalpy.models.baselines.sklearn_models import SklearnModel
+from drevalpy.models.utils import load_single_cell_line_view
+
+_GENE_EXPRESSION = (
+    "cellosaurus_id,cell_line_name,TSPAN6,TNMD,BRCA1,SCYL3,HDAC1,INSIG1,FOXO3\n"
+    "CVCL_1104,CAL-120,7.63,2.96,10.38,3.61,3.38,7.09,3.02\n"
+    "CVCL_1174,DMS 114,7.55,2.78,11.81,4.07,3.73,2.80,6.08\n"
+    "CVCL_1110,CAL-51,8.71,2.64,9.88,3.96,3.24,11.39,4.22\n"
+)
+#: Symbols of the two gene lists written by the gene_list_data_dir fixture.
+_LANDMARK_GENES = ["BRCA1", "SCYL3", "INSIG1", "FOXO3"]
+_TARGET_GENES = ["TSPAN6", "SCYL3", "BRCA1"]
+_ALL_GENES = ["TSPAN6", "TNMD", "BRCA1", "SCYL3", "HDAC1", "INSIG1", "FOXO3"]
+
+
+@pytest.fixture
+def gene_list_data_dir(tmp_path) -> str:
+    """
+    Build a minimal data directory with a gene expression matrix and two gene lists.
+
+    :param tmp_path: pytest temporary path fixture
+    :returns: path to the data directory
+    """
+    dataset_dir = tmp_path / "GDSC1_small"
+    dataset_dir.mkdir()
+    (dataset_dir / "gene_expression.csv").write_text(_GENE_EXPRESSION, encoding="utf-8")
+
+    gene_lists = tmp_path / "meta" / "gene_lists"
+    gene_lists.mkdir(parents=True)
+    (gene_lists / "landmark_genes_reduced.csv").write_text(
+        "Entrez ID,Symbol,Name,Gene Family,Type,RNA-Seq Correlation,RNA-Seq Correlation Self-Rank\n"
+        "3638,INSIG1,insulin induced gene 1,,landmark,,\n"
+        "2309,FOXO3,forkhead box O3,Forkhead boxes,landmark,,\n"
+        "672,BRCA1,BRCA1 DNA repair associated,,landmark,,\n"
+        "57147,SCYL3,SCY1 like pseudokinase 3,SCY1 like pseudokinases,landmark,,\n",
+        encoding="utf-8",
+    )
+    (gene_lists / "drug_target_genes_all_drugs.csv").write_text("Symbol\nTSPAN6\nSCYL3\nBRCA1\n", encoding="utf-8")
+    return str(tmp_path)
+
+
+def _gene_names(features) -> list[str]:
+    """
+    Extract the gene symbols of the gene_expression view.
+
+    :param features: FeatureDataset returned by a loader
+    :returns: gene symbols
+    """
+    assert features.meta_info is not None
+    return list(features.meta_info["gene_expression"])
+
+
+def test_load_single_cell_line_view_defaults_to_landmark_genes(gene_list_data_dir) -> None:
+    """
+    Omitting gene_list must reproduce the previously hard-coded landmark_genes_reduced behaviour.
+
+    :param gene_list_data_dir: path to the temporary data directory
+    """
+    features = load_single_cell_line_view(["gene_expression"], gene_list_data_dir, "GDSC1_small", "ElasticNet")
+    assert sorted(_gene_names(features)) == sorted(_LANDMARK_GENES)
+
+
+def test_load_single_cell_line_view_honours_explicit_gene_list(gene_list_data_dir) -> None:
+    """
+    A different gene list has to change which genes are loaded.
+
+    :param gene_list_data_dir: path to the temporary data directory
+    """
+    features = load_single_cell_line_view(
+        ["gene_expression"],
+        gene_list_data_dir,
+        "GDSC1_small",
+        "ElasticNet",
+        gene_list="drug_target_genes_all_drugs",
+    )
+    assert sorted(_gene_names(features)) == sorted(_TARGET_GENES)
+
+
+def test_load_single_cell_line_view_gene_list_none_loads_all_genes(gene_list_data_dir) -> None:
+    """
+    gene_list=None has to load the full expression matrix.
+
+    :param gene_list_data_dir: path to the temporary data directory
+    """
+    features = load_single_cell_line_view(
+        ["gene_expression"], gene_list_data_dir, "GDSC1_small", "ElasticNet", gene_list=None
+    )
+    assert sorted(_gene_names(features)) == sorted(_ALL_GENES)
+
+
+def test_sklearn_model_gene_list_default() -> None:
+    """Without the hyperparameter the model keeps the class default."""
+    model = MODEL_FACTORY["ElasticNet"]()
+    model.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2})
+    assert model.gene_list == SklearnModel.gene_list == "landmark_genes_reduced"
+
+
+def test_sklearn_model_gene_list_hyperparameter(gene_list_data_dir) -> None:
+    """
+    The "gene_list" hyperparameter has to reach load_cell_line_features.
+
+    :param gene_list_data_dir: path to the temporary data directory
+    """
+    model = MODEL_FACTORY["ElasticNet"]()
+    model.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2, "gene_list": "drug_target_genes_all_drugs"})
+    assert model.gene_list == "drug_target_genes_all_drugs"
+    # It stays in the hyperparameters, so save()/load() carry it over to predict().
+    assert model.hyperparameters["gene_list"] == "drug_target_genes_all_drugs"
+
+    features = model.load_cell_line_features(data_path=gene_list_data_dir, dataset_name="GDSC1_small")
+    assert sorted(_gene_names(features)) == sorted(_TARGET_GENES)
+    # The class default is untouched, only the instance was reconfigured.
+    assert SklearnModel.gene_list == "landmark_genes_reduced"
+
+
+def test_sklearn_model_gene_list_does_not_leak_between_instances(gene_list_data_dir) -> None:
+    """
+    A second model built without the hyperparameter must fall back to the default again.
+
+    :param gene_list_data_dir: path to the temporary data directory
+    """
+    configured = MODEL_FACTORY["ElasticNet"]()
+    configured.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2, "gene_list": None})
+    assert configured.gene_list is None
+    assert sorted(_gene_names(configured.load_cell_line_features(gene_list_data_dir, "GDSC1_small"))) == sorted(
+        _ALL_GENES
+    )
+
+    default = MODEL_FACTORY["ElasticNet"]()
+    default.build_model(hyperparameters={"alpha": 1.0, "l1_ratio": 0.2})
+    assert sorted(_gene_names(default.load_cell_line_features(gene_list_data_dir, "GDSC1_small"))) == sorted(
+        _LANDMARK_GENES
+    )


### PR DESCRIPTION
# PR Checklist for all PRs

- [x] This comment contains a description of changes (with reason)
- [ ] Referenced issue is linked — no existing issue, came up while benchmarking baselines on other gene spaces
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated — no new module and no signature that the API docs render, so nothing to add

### Changes

### New features

`load_single_cell_line_view` hard-codes the gene list it subsets `gene_expression` with:

```python
if "gene_expression" in cell_line_views:
    return load_and_select_gene_features(
        feature_type="gene_expression",
        gene_list="landmark_genes_reduced",
        ...
    )
```

So every single-view sklearn baseline — `ElasticNet`, `RandomForest`, `SVR`, `SingleDrug*`, … — is
locked to the landmark genes. The other gene lists that ship with the framework
(`drug_target_genes_all_drugs`, `gene_list=None` for the full matrix) are reachable for hand-written
models, but not for the baselines, even though the baselines are exactly where one wants to vary the
feature space to see how much of a model's performance comes from the gene selection rather than the
learner.

This makes it configurable in two steps, without changing any default:

1. `load_single_cell_line_view` gains `gene_list: str | None = "landmark_genes_reduced"` and forwards it.
   The default is the previously hard-coded value, so every existing caller behaves exactly as before.
2. `SklearnModel` gains a `gene_list` class attribute with the same default, and `build_model` reads it
   from the hyperparameters:

   ```python
   self.gene_list = hyperparameters.get("gene_list", type(self).gene_list)
   ```

   This is the same pattern the class already uses for `cell_line_views` and `drug_views` one line above.
   The value stays in `self.hyperparameters`, so `save()`/`load()` carry it and `predict()` uses the same
   gene space the model was trained on.

`gene_list` is deliberately **not** added to `baselines/hyperparameters.yaml`, so the tuning grids are
untouched and nothing changes for existing runs. It becomes available to anyone who passes a custom
hyperparameter set.

Tests: `tests/test_sklearn_gene_list.py` builds a temporary `meta/gene_lists` directory with two lists
and covers

* omitting `gene_list` reproduces the previously hard-coded `landmark_genes_reduced` behaviour
* an explicit list is honoured
* `gene_list=None` loads the full expression matrix
* the `SklearnModel` default equals the class attribute
* the `"gene_list"` hyperparameter reaches `load_cell_line_features` and lands in `self.hyperparameters`
* setting it on one instance does not leak into the class attribute or into other instances

### Bug fixes

### Maintenance
