### PR TITLE
fix(DIPK): keep the autoencoder gene expression matrices in host memory

### DIFF
--- a/drevalpy/models/DIPK/gene_expression_encoder.py
+++ b/drevalpy/models/DIPK/gene_expression_encoder.py
@@ -141,6 +141,39 @@ class DataSet(Dataset, ABC):
         return len(self._data)
 
 
+def _validation_loss(
+    encoder: GeneExpressionEncoder,
+    decoder: GeneExpressionDecoder,
+    gene_expression_val_tensor: torch.Tensor,
+    batch_size: int,
+    device: torch.device,
+) -> float:
+    """Compute the reconstruction MSE of the validation matrix in chunks.
+
+    Sum of squared errors and element count are accumulated exactly, so the result is identical
+    to nn.MSELoss() over the whole matrix, but only one batch has to live on the device.
+
+    :param encoder: encoder in eval mode
+    :param decoder: decoder in eval mode
+    :param gene_expression_val_tensor: validation matrix, kept on the host
+    :param batch_size: number of rows moved to the device at a time
+    :param device: device the models live on
+    :return: mean squared reconstruction error, nan for an empty validation matrix
+    """
+    squared_error = 0.0
+    elements = 0
+    with torch.no_grad():
+        for start in range(0, len(gene_expression_val_tensor), batch_size):
+            stop = start + batch_size
+            val_batch = gene_expression_val_tensor[start:stop].to(device)
+            val_output = decoder(encoder(val_batch))
+            squared_error += float(((val_output - val_batch) ** 2).sum().item())
+            elements += val_batch.numel()
+    if elements == 0:
+        return float("nan")
+    return squared_error / elements
+
+
 def train_gene_expession_autoencoder(
     gene_expression_input: np.ndarray, gene_expression_input_early_stopping: np.ndarray, epochs_autoencoder: int = 100
 ) -> GeneExpressionEncoder:
@@ -164,14 +197,18 @@ def train_gene_expession_autoencoder(
     optimizer = optim.Adam(params, lr=lr)
 
     # load data
+    # The full training matrix stays in host memory, only the mini batches are moved to the device
+    # (the training loop below already calls .to(device) per batch). With large gene lists the
+    # complete matrix does not fit into GPU memory: 230k response rows x 11,883 genes x 4 byte is
+    # ~11 GB, while a batch of 1024 rows is ~50 MB. Semantics are unchanged.
     my_collate = CollateFn()
-    gene_expression_tensor = torch.tensor(gene_expression_input, dtype=torch.float32).to(device)
+    gene_expression_tensor = torch.from_numpy(np.asarray(gene_expression_input, dtype=np.float32))
     train_loader = DataLoader(
         DataSet(gene_expression_tensor), batch_size=batch_size, shuffle=True, collate_fn=my_collate
     )
 
-    # prepare early stopping validation data
-    gene_expression_val_tensor = torch.tensor(gene_expression_input_early_stopping, dtype=torch.float32).to(device)
+    # prepare early stopping validation data (kept on the host as well, evaluated in chunks below)
+    gene_expression_val_tensor = torch.from_numpy(np.asarray(gene_expression_input_early_stopping, dtype=np.float32))
 
     # early stopping parameters
     patience = 3
@@ -206,9 +243,7 @@ def train_gene_expession_autoencoder(
         # validation
         encoder.eval()
         decoder.eval()
-        with torch.no_grad():
-            val_output = decoder(encoder(gene_expression_val_tensor))
-            val_loss = loss_func(val_output, gene_expression_val_tensor).item()
+        val_loss = _validation_loss(encoder, decoder, gene_expression_val_tensor, batch_size, device)
 
         print(f"DIPK Autoenc. Epoch: {epoch_index}, Train Loss: {epoch_loss}, Val Loss: {val_loss}")
 

--- a/drevalpy/models/DIPK/gene_expression_encoder.py
+++ b/drevalpy/models/DIPK/gene_expression_encoder.py
@@ -198,9 +198,10 @@ def train_gene_expession_autoencoder(
 
     # load data
     # The full training matrix stays in host memory, only the mini batches are moved to the device
-    # (the training loop below already calls .to(device) per batch). With large gene lists the
-    # complete matrix does not fit into GPU memory: 230k response rows x 11,883 genes x 4 byte is
-    # ~11 GB, while a batch of 1024 rows is ~50 MB. Semantics are unchanged.
+    # (the training loop below already calls .to(device) per batch). The matrix holds one row per
+    # response, not per cell line, so it is large: a GDSC1 training fold has ~270k rows, which is
+    # ~2.5 GB of float32 with the 2.3k genes of the default gene_expression_intersection list and
+    # ~13 GB with a 12k gene list. A batch of 1024 rows is ~50 MB. Semantics are unchanged.
     my_collate = CollateFn()
     gene_expression_tensor = torch.from_numpy(np.asarray(gene_expression_input, dtype=np.float32))
     train_loader = DataLoader(

--- a/tests/test_dipk_autoencoder_memory.py
+++ b/tests/test_dipk_autoencoder_memory.py
@@ -1,0 +1,106 @@
+"""Tests for the chunked, host-memory validation pass of the DIPK gene expression autoencoder."""
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from drevalpy.models.DIPK import gene_expression_encoder as gee
+from drevalpy.models.DIPK.gene_expression_encoder import (
+    GeneExpressionDecoder,
+    GeneExpressionEncoder,
+    _validation_loss,
+    train_gene_expession_autoencoder,
+)
+
+_N_GENES = 16
+_CPU = torch.device("cpu")
+
+
+def _models() -> tuple[GeneExpressionEncoder, GeneExpressionDecoder]:
+    """
+    Build an encoder/decoder pair in eval mode, so dropout and batch norm are deterministic.
+
+    :returns: encoder and decoder
+    """
+    torch.manual_seed(0)
+    encoder = GeneExpressionEncoder(_N_GENES)
+    decoder = GeneExpressionDecoder(_N_GENES)
+    encoder.eval()
+    decoder.eval()
+    return encoder, decoder
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 7, 10, 1024])
+def test_chunked_validation_loss_matches_full_mse(batch_size: int) -> None:
+    """The chunked pass has to return exactly what MSELoss over the whole matrix returns.
+
+    :param batch_size: number of rows evaluated at a time, deliberately including sizes that do
+        not divide the number of validation rows
+    """
+    encoder, decoder = _models()
+    validation = torch.randn(10, _N_GENES)
+
+    with torch.no_grad():
+        expected = nn.MSELoss()(decoder(encoder(validation)), validation).item()
+
+    assert _validation_loss(encoder, decoder, validation, batch_size, _CPU) == pytest.approx(expected, rel=1e-5)
+
+
+def test_validation_loss_leaves_the_input_untouched() -> None:
+    """The validation matrix is only read, the chunks are copies moved to the device."""
+    encoder, decoder = _models()
+    validation = torch.randn(5, _N_GENES)
+    before = validation.clone()
+
+    _validation_loss(encoder, decoder, validation, 2, _CPU)
+
+    assert validation.device == _CPU
+    assert torch.equal(validation, before)
+
+
+def test_validation_loss_of_an_empty_matrix_is_nan() -> None:
+    """An empty early stopping set must not raise a ZeroDivisionError."""
+    encoder, decoder = _models()
+
+    assert np.isnan(_validation_loss(encoder, decoder, torch.empty(0, _N_GENES), 4, _CPU))
+
+
+def test_training_keeps_the_full_matrices_in_host_memory(monkeypatch) -> None:
+    """Only mini batches may be moved to the device, the full matrices stay on the host.
+
+    On a CUDA host the previous implementation handed a device tensor to the DataLoader, which is
+    what runs out of GPU memory for large gene lists.
+
+    :param monkeypatch: pytest monkeypatch fixture, used to capture the DataLoader input
+    """
+    captured: list[torch.Tensor] = []
+    original_dataset = gee.DataSet
+
+    def _capturing_dataset(data):
+        captured.append(data)
+        return original_dataset(data)
+
+    monkeypatch.setattr(gee, "DataSet", _capturing_dataset)
+    train = np.random.default_rng(0).normal(size=(8, _N_GENES))
+    validation = np.random.default_rng(1).normal(size=(3, _N_GENES))
+
+    train_gene_expession_autoencoder(train, validation, epochs_autoencoder=1)
+
+    assert len(captured) == 1
+    assert captured[0].device == _CPU
+    assert captured[0].dtype == torch.float32
+
+
+def test_training_runs_with_a_validation_set_smaller_than_the_batch() -> None:
+    """Smoke test over the changed code path: float64 input, validation rows not a multiple of the batch."""
+    train = np.random.default_rng(0).normal(size=(8, _N_GENES))
+    validation = np.random.default_rng(1).normal(size=(3, _N_GENES))
+
+    encoder = train_gene_expession_autoencoder(train, validation, epochs_autoencoder=2)
+
+    assert isinstance(encoder, GeneExpressionEncoder)
+    assert not encoder.training
+    device = next(encoder.parameters()).device
+    with torch.no_grad():
+        assert encoder(torch.from_numpy(validation.astype(np.float32)).to(device)).shape == (3, encoder.latent_dim)


### PR DESCRIPTION
# PR Checklist for all PRs

- [x] This comment contains a description of changes (with reason)
- [ ] Referenced issue is linked — no existing issue, hit this while running DIPK on GDSC1 with the full gene set
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated — no new module, no new option, no changed signature; the fix is internal to `train_gene_expession_autoencoder`

### Changes

### Bug fixes

`train_gene_expession_autoencoder` moves **both complete gene expression matrices** to the GPU before
training starts:

```python
gene_expression_tensor = torch.tensor(gene_expression_input, dtype=torch.float32).to(device)
...
gene_expression_val_tensor = torch.tensor(gene_expression_input_early_stopping, dtype=torch.float32).to(device)
```

The matrices are not one row per cell line — `dipk.py` builds them with
`get_feature_matrix(view="gene_expression", identifiers=output.cell_line_ids)`, i.e. **one row per response
row**, with the expression profile of a cell line repeated for each of its drugs. GDSC1 has ~316k responses, so
a training fold of a 7-fold CV is ~270k rows. With the gene list DIPK hard-codes
(`gene_expression_intersection`, ~2.3k genes) that is **~2.5 GB for the training matrix alone**, plus the
validation matrix, allocated before a single batch exists. With a larger expression panel — we run DIPK against
a ~12k-gene list — it is ~13 GB and the run dies with a CUDA OOM during setup on anything short of a very large
card.

The training loop does not need the matrix on the device at all — it already moves every mini batch itself:

```python
for gene_expression_batch in train_loader:
    gene_expression_batch = gene_expression_batch.to(device)
```

So both matrices now stay in host memory and only the batches are transferred. A batch of 1024 rows is ~50 MB
even for a 12k-gene panel. `torch.from_numpy(np.asarray(x, dtype=np.float32))` replaces `torch.tensor(...)`, which also
avoids one full copy when the input is already float32; the tensor is only ever read (`DataSet.__getitem__`
indexes it and `CollateFn` calls `torch.stack`, which copies), so nothing aliases into the caller's array in a
way that could be mutated.

The validation pass was the one place that genuinely needed the whole matrix on the device, because it did a
single forward over all of it:

```python
val_output = decoder(encoder(gene_expression_val_tensor))
val_loss = loss_func(val_output, gene_expression_val_tensor).item()
```

That is now `_validation_loss`, which walks the matrix in chunks of `batch_size` and accumulates the **sum of
squared errors and the element count**, then divides once. Because both are accumulated exactly, the result is
the same number `nn.MSELoss()` over the full matrix returns — the early stopping decision is bit-for-bit the
one it was before, it just never holds more than one batch on the device. An empty validation matrix returns
`nan` instead of raising `ZeroDivisionError`.

**No behaviour changes:** same losses, same early stopping, same returned encoder. Only the peak device memory
drops from "whole dataset" to "one batch".

Tests: `tests/test_dipk_autoencoder_memory.py`

* `_validation_loss` equals `nn.MSELoss()` over the whole matrix, parametrized over batch sizes 1, 3, 7, 10 and
  1024 — deliberately including sizes that do not divide the 10 validation rows, and one larger than the matrix
* the validation matrix is left on the host and unmodified
* an empty validation matrix yields `nan` rather than a `ZeroDivisionError`
* the tensor handed to the `DataLoader` is on the CPU and is float32 (this is the assertion that would have
  caught the original bug — on a CUDA host the old code put a device tensor there)
* a smoke test over the whole changed path with float64 input and a validation set smaller than the batch

### New features

### Maintenance
