### PR TITLE
fix: final model of a single drug model is trained on all drugs

### DIFF
--- a/drevalpy/experiment.py
+++ b/drevalpy/experiment.py
@@ -461,6 +461,7 @@ def drug_response_experiment(
             train_final_model(
                 model_class=model_class,
                 full_dataset=response_data.copy(),
+                drug_id=drug_id,
                 response_transformation=response_transformation,
                 path_data=path_data,
                 model_checkpoint_dir=model_checkpoint_dir,
@@ -1560,6 +1561,7 @@ def train_final_model(
     model_checkpoint_dir: str,
     metric: str,
     final_model_path: str,
+    drug_id: str | None = None,
     test_mode: str = "LCO",
     val_ratio: float = 0.1,
     hyperparameter_tuning: bool = True,
@@ -1583,13 +1585,23 @@ def train_final_model(
     :param model_checkpoint_dir: checkpoint dir for intermediate tuning models
     :param metric: metric for tuning, e.g., "RMSE"
     :param final_model_path: path to final_model save directory
+    :param drug_id: drug id for single drug models. The dataset is reduced to this drug, analogous to
+        get_datasets_from_cv_split, because a single drug model is fitted per drug.
     :param test_mode: split logic for validation (LCO, LDO, LTO, LPO)
     :param val_ratio: validation size ratio
     :param hyperparameter_tuning: whether to perform hyperparameter tuning
+    :raises ValueError: if a single drug model is trained without a drug id
     """
     print("Training final model with application-specific validation strategy ...")
 
     full_dataset.remove_nan_responses()
+    if model_class.is_single_drug_model:
+        if drug_id is None:
+            raise ValueError(
+                f"{model_class.get_model_name()} is a single drug model, so a drug_id is required to train the "
+                f"final model. Otherwise the model would be fitted on the responses of all drugs."
+            )
+        full_dataset.mask(full_dataset.drug_ids == drug_id)
     model = model_class()
     train_dataset, validation_dataset = make_train_val_split(full_dataset, test_mode=test_mode, val_ratio=val_ratio)
 

--- a/tests/test_final_model_single_drug.py
+++ b/tests/test_final_model_single_drug.py
@@ -1,0 +1,260 @@
+"""Tests that the final model of a single drug model is fitted on the responses of that drug only."""
+
+import os
+from typing import Any
+
+import numpy as np
+import pytest
+from sklearn.preprocessing import StandardScaler
+
+from drevalpy.datasets.dataset import DrugResponseDataset, FeatureDataset
+from drevalpy.experiment import train_final_model
+from drevalpy.models.drp_model import DRPModel
+
+_CELL_LINES = np.array([f"CL-{i}" for i in range(20)])
+_DRUGS = np.array(["Drug-1", "Drug-2"])
+
+
+class _RecordingModel(DRPModel):
+    """Model that only records which responses it was trained on."""
+
+    cell_line_views = ["gene_expression"]
+    drug_views: list[str] = []
+    early_stopping = False
+    #: Responses of the last train() call, class level so the test sees them without the instance.
+    seen_drug_ids: np.ndarray = np.array([])
+    #: Cell lines the in memory features are built for, class level so a test can point it at real data.
+    cell_lines: np.ndarray = _CELL_LINES
+
+    @classmethod
+    def get_model_name(cls) -> str:
+        """
+        Returns the model name.
+
+        :returns: RecordingModel
+        """
+        return "RecordingModel"
+
+    @classmethod
+    def get_hyperparameter_set(cls) -> list[dict[str, Any]]:
+        """
+        Avoids reading a hyperparameters.yaml next to this test file.
+
+        :returns: a single empty hyperparameter set
+        """
+        return [{}]
+
+    def build_model(self, hyperparameters: dict[str, Any]) -> None:
+        """
+        Nothing to build.
+
+        :param hyperparameters: unused
+        """
+
+    def train(
+        self,
+        output: DrugResponseDataset,
+        cell_line_input: FeatureDataset,
+        drug_input: FeatureDataset | None = None,
+        output_earlystopping: DrugResponseDataset | None = None,
+        model_checkpoint_dir: str = "checkpoints",
+    ) -> None:
+        """
+        Records the drug ids of the training data.
+
+        :param output: training data
+        :param cell_line_input: cell line features
+        :param drug_input: drug features
+        :param output_earlystopping: early stopping data
+        :param model_checkpoint_dir: unused
+        """
+        type(self).seen_drug_ids = np.array(output.drug_ids)
+
+    def predict(
+        self,
+        cell_line_ids: np.ndarray,
+        drug_ids: np.ndarray,
+        cell_line_input: FeatureDataset,
+        drug_input: FeatureDataset | None = None,
+    ) -> np.ndarray:
+        """
+        Predicts zeros.
+
+        :param cell_line_ids: cell line ids
+        :param drug_ids: drug ids
+        :param cell_line_input: cell line features
+        :param drug_input: drug features
+        :returns: zeros
+        """
+        return np.zeros(len(cell_line_ids))
+
+    def load_cell_line_features(self, data_path: str, dataset_name: str) -> FeatureDataset:
+        """
+        Builds the features in memory, no data directory is read.
+
+        :param data_path: unused
+        :param dataset_name: unused
+        :returns: one feature per cell line
+        """
+        return FeatureDataset(
+            features={cl: {"gene_expression": np.array([float(i)])} for i, cl in enumerate(type(self).cell_lines)}
+        )
+
+    def load_drug_features(self, data_path: str, dataset_name: str) -> FeatureDataset | None:
+        """
+        Single drug models do not use drug features.
+
+        :param data_path: unused
+        :param dataset_name: unused
+        :returns: None
+        """
+        return None
+
+    def save(self, directory: str) -> None:
+        """
+        Writes a marker file so the test can see that the final model was saved.
+
+        :param directory: target directory
+        """
+        with open(os.path.join(directory, "saved.txt"), "w", encoding="utf-8") as handle:
+            handle.write(str(len(type(self).seen_drug_ids)))
+
+
+class _SingleDrugRecordingModel(_RecordingModel):
+    """Single drug variant, i.e., the pipeline fits one model per drug."""
+
+    is_single_drug_model = True
+
+    @classmethod
+    def get_model_name(cls) -> str:
+        """
+        Returns the model name.
+
+        :returns: SingleDrugRecordingModel
+        """
+        return "SingleDrugRecordingModel"
+
+
+@pytest.fixture
+def full_dataset() -> DrugResponseDataset:
+    """
+    Responses of two drugs on the same cell lines.
+
+    :returns: dataset with 40 responses, 20 per drug
+    """
+    cell_line_ids = np.tile(_CELL_LINES, len(_DRUGS))
+    drug_ids = np.repeat(_DRUGS, len(_CELL_LINES))
+    return DrugResponseDataset(
+        response=np.arange(len(cell_line_ids), dtype=float),
+        cell_line_ids=cell_line_ids,
+        drug_ids=drug_ids,
+        dataset_name="Toy_Data",
+    )
+
+
+def _train(model_class: type[DRPModel], dataset: DrugResponseDataset, path: str, drug_id: str | None) -> None:
+    """
+    Run train_final_model with the arguments the pipeline uses.
+
+    :param model_class: model to train
+    :param dataset: full dataset
+    :param path: final model directory
+    :param drug_id: drug id handed over by the pipeline for single drug models
+    """
+    train_final_model(
+        model_class=model_class,
+        full_dataset=dataset,
+        drug_id=drug_id,
+        # The pipeline may also hand over None here, but that contradicts the annotation of train_final_model.
+        response_transformation=StandardScaler(),
+        path_data="",
+        model_checkpoint_dir="",
+        metric="RMSE",
+        final_model_path=path,
+        test_mode="LCO",
+        hyperparameter_tuning=False,
+    )
+
+
+def test_final_model_of_a_single_drug_model_only_sees_its_own_drug(full_dataset, tmp_path) -> None:
+    """
+    The final model has to be fitted per drug, like every other step of a single drug model.
+
+    :param full_dataset: responses of two drugs
+    :param tmp_path: pytest temporary path fixture
+    """
+    for drug_id in _DRUGS:
+        _train(_SingleDrugRecordingModel, full_dataset.copy(), str(tmp_path / str(drug_id)), str(drug_id))
+        seen = _SingleDrugRecordingModel.seen_drug_ids
+        assert len(seen) > 0
+        assert set(seen) == {drug_id}, f"final model of {drug_id} was trained on {set(seen)}"
+        assert os.path.isfile(tmp_path / str(drug_id) / "saved.txt")
+
+
+def test_final_model_of_a_single_drug_model_requires_a_drug_id(full_dataset, tmp_path) -> None:
+    """
+    Without a drug id the model would silently be fitted on all drugs, so it has to fail loudly.
+
+    :param full_dataset: responses of two drugs
+    :param tmp_path: pytest temporary path fixture
+    """
+    with pytest.raises(ValueError, match="single drug model"):
+        _train(_SingleDrugRecordingModel, full_dataset.copy(), str(tmp_path / "no_drug"), None)
+
+
+def test_final_model_of_a_multi_drug_model_still_sees_all_drugs(full_dataset, tmp_path) -> None:
+    """
+    Multi drug models are unaffected by the fix.
+
+    :param full_dataset: responses of two drugs
+    :param tmp_path: pytest temporary path fixture
+    """
+    _train(_RecordingModel, full_dataset.copy(), str(tmp_path / "multi"), None)
+    assert set(_RecordingModel.seen_drug_ids) == set(_DRUGS)
+
+
+def test_pipeline_hands_the_drug_id_to_the_final_model(monkeypatch, sample_dataset, data_dir, tmp_path) -> None:
+    """
+    The call site in drug_response_experiment has to pass the drug id of the current model.
+
+    :param monkeypatch: pytest monkeypatch fixture
+    :param sample_dataset: TOYv1, needed because the pipeline always adds NaiveMeanEffectsPredictor
+    :param data_dir: path to the data directory
+    :param tmp_path: pytest temporary path fixture
+    """
+    from drevalpy import experiment as experiment_module
+    from drevalpy.models import MODEL_FACTORY, SINGLE_DRUG_MODEL_FACTORY
+
+    response_data = sample_dataset.copy()
+    two_drugs = sorted(np.unique(response_data.drug_ids))[:2]
+    response_data.mask(np.isin(response_data.drug_ids, two_drugs))
+
+    monkeypatch.setitem(MODEL_FACTORY, "SingleDrugRecordingModel", _SingleDrugRecordingModel)
+    monkeypatch.setitem(SINGLE_DRUG_MODEL_FACTORY, "SingleDrugRecordingModel", _SingleDrugRecordingModel)
+    monkeypatch.setattr(_RecordingModel, "cell_lines", np.unique(response_data.cell_line_ids))
+
+    calls: list[dict] = []
+
+    def _record(**kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(experiment_module, "train_final_model", _record)
+
+    experiment_module.drug_response_experiment(
+        models=[_SingleDrugRecordingModel],
+        baselines=[],
+        response_data=response_data,
+        run_id="single_drug_final_model",
+        path_data=str(data_dir),
+        path_out=str(tmp_path),
+        test_mode="LCO",
+        n_cv_splits=2,
+        hyperparameter_tuning=False,
+        final_model_on_full_data=True,
+        overwrite=True,
+    )
+
+    # One final model per drug, each with its own drug id and the full, unmasked dataset.
+    assert [call["drug_id"] for call in calls] == list(two_drugs)
+    for call in calls:
+        assert set(call["full_dataset"].drug_ids) == set(two_drugs)


### PR DESCRIPTION
# PR Checklist for all PRs

- [x] This comment contains a description of changes (with reason)
- [ ] Referenced issue is linked — no existing issue, this turned up while looking for saved single drug models in a results directory
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated — not needed, `drevalpy.experiment` is already an `automodule` and the new parameter is documented in the `train_final_model` docstring

### Changes

### Bug fixes

With `final_model_on_full_data`, the final model of a **single drug model is fitted on the responses of all
drugs**, and that model is then saved under `<model>/drugs/<drug_id>/final_model/`.

Where it comes from: `make_model_list` creates one entry per drug for a single drug model, so the loop body —
including the `train_final_model` call — runs once per drug. The CV path masks the data for that drug in
`get_datasets_from_cv_split`:

```python
if model_name in SINGLE_DRUG_MODEL_FACTORY.keys():
    output_mask = train_dataset.drug_ids == drug_id
    train_dataset.mask(output_mask)
    ...
```

but `train_final_model` is handed `response_data.copy()` and never learns which drug it is training for. It
does not fail, it just trains on everything, so each per-drug directory ends up holding a drug-agnostic model.
With `hyperparameter_tuning=True` the same applies to the tuning that precedes it: it is repeated per drug on
the full dataset.

Observed on a two-drug subset of GDSC1 (1920 responses, LCO, 2 splits, no tuning) with
`models=[SingleDrugRandomForest]`:

```
Running SingleDrugRandomForest.9858940
...
Training final model with application-specific validation strategy ...
Reduced training dataset from 1920 to 1874, due to missing features   # <- both drugs
```

while the CV steps of the same run trained on ~480 responses per drug and split. Checking the two saved
forests confirms it: the root node of the first tree holds 339 and 347 samples, which is what
`max_samples=0.2` gives for 1874 training rows — one drug alone (~937 rows) would give ~170.

Fix: `train_final_model` takes the `drug_id` that the pipeline already has and reduces the dataset the same way
the CV path does. Passing no `drug_id` for a single drug model now raises instead of silently pooling the
drugs. Multi-drug models are unaffected, and the `model_class not in baselines` condition is untouched —
baselines not getting a final model is a separate, deliberate decision.

Tests: `tests/test_final_model_single_drug.py`

* the final model of each drug is trained on that drug's responses only, and is saved
* a single drug model without a `drug_id` raises `ValueError`
* a multi-drug model still sees all drugs
* the call site in `drug_response_experiment` hands over the drug id of the current model, once per drug

The tests use small recording models that build their features in memory, so they do not need a data
directory; only the wiring test loads TOYv1 because the pipeline always adds `NaiveMeanEffectsPredictor`.
All four fail without the fix.

One thing I left alone: `train_final_model` is annotated `response_transformation: TransformerMixin`, but
`drug_response_experiment` passes `TransformerMixin | None` (default `None`) straight through. That is
harmless at runtime but would trip typeguard for a run without a response transformation. Happy to widen the
annotation here if you'd rather have it in this PR.

### New features

### Maintenance
